### PR TITLE
handling nested pickers

### DIFF
--- a/lua/telescope-picker-list/init.lua
+++ b/lua/telescope-picker-list/init.lua
@@ -29,12 +29,18 @@ for name, item in pairs(builtin_pickers) do
   end
 end
 
-for name, item in pairs(extensions_pickers.manager) do
-  if not (vim.tbl_contains(excluded, name)) then
-    result_table[name] = {
-      action = funcs[name] or item[name] or function() end,
-      opt = plugin_opts[name] or opts_pickers,
-    }
+for extension, item in pairs(extensions_pickers.manager) do
+  if not (vim.tbl_contains(excluded, extension)) then
+    for name, action in pairs(item) do
+      local key = extension
+      if name ~= extension and #vim.tbl_keys(item) > 1 then
+        key = key .. ": " .. name
+      end
+      result_table[key] = {
+        action = action,
+        opt = plugin_opts[extension] or opts_pickers,
+      }
+    end
   end
 end
 

--- a/lua/telescope-picker-list/init.lua
+++ b/lua/telescope-picker-list/init.lua
@@ -8,10 +8,11 @@ local opts_pickers = {
   winnr = vim.api.nvim_get_current_win(),
 }
 
-local excluded = extensions_pickers._config.picker_list.excluded_pickers or {}
-local plugin_opts = extensions_pickers._config.picker_list.opts or {}
-local funcs = extensions_pickers._config.picker_list.actions or {}
-local user_pickers = extensions_pickers._config.picker_list.user_pickers or {}
+local picker_list = extensions_pickers._config.picker_list or {}
+local excluded = picker_list.excluded_pickers or {}
+local plugin_opts = picker_list.opts or {}
+local funcs = picker_list.actions or {}
+local user_pickers = picker_list.user_pickers or {}
 
 for _, v in ipairs(user_pickers) do
   result_table[v[1]] = {

--- a/lua/telescope-picker-list/init.lua
+++ b/lua/telescope-picker-list/init.lua
@@ -33,7 +33,7 @@ for extension, item in pairs(extensions_pickers.manager) do
   if not (vim.tbl_contains(excluded, extension)) then
     for name, action in pairs(item) do
       local key = extension
-      if name ~= extension and #vim.tbl_keys(item) > 1 then
+      if name ~= extension and vim.tbl_count(item) > 1 then
         key = key .. ": " .. name
       end
       result_table[key] = {


### PR DESCRIPTION
Some plugins have nested pickers such as https://github.com/dawsers/telescope-file-history.nvim and so `_extensions.manager` will contain multiple actions within an extension. This handles that case by showing all of those pickers separately. For example:

<img width="734" alt="image" src="https://github.com/OliverChao/telescope-picker-list.nvim/assets/932940/7ed90a93-0785-405a-9c4c-da621bcabb62">

In addition some pickers dont have the same same name for the picker as the extension name. for example https://github.com/LukasPietzschmann/telescope-tabs has this in the `manager`:

```
    ["telescope-tabs"] = {
      list_tabs = <function 9>
    },
```