### PR TITLE
fix: 'no client attached' when selecting LSP-related pickers

### DIFF
--- a/lua/telescope-picker-list/init.lua
+++ b/lua/telescope-picker-list/init.lua
@@ -4,11 +4,6 @@ local extensions_pickers = require("telescope._extensions")
 local M = {}
 M.results = {}
 
-local opts_pickers = {
-	bufnr = vim.api.nvim_get_current_buf(),
-	winnr = vim.api.nvim_get_current_win(),
-}
-
 local picker_list = extensions_pickers._config.picker_list or {}
 local excluded = picker_list.excluded_pickers or {}
 local plugin_opts = picker_list.opts or {}
@@ -25,7 +20,7 @@ function M.register(_name)
 			end
 			M.results[key] = {
 				action = action,
-				opt = plugin_opts[_name] or opts_pickers,
+				opt = plugin_opts[_name] or {},
 			}
 		end
 	end
@@ -41,7 +36,7 @@ for name, item in pairs(builtin_pickers) do
 	if not (vim.tbl_contains(excluded, name)) then
 		M.results[name] = {
 			action = funcs[name] or item or function() end,
-			opt = plugin_opts[name] or opts_pickers,
+			opt = plugin_opts[name] or {},
 		}
 	end
 end

--- a/lua/telescope/_extensions/picker_list/main.lua
+++ b/lua/telescope/_extensions/picker_list/main.lua
@@ -12,6 +12,13 @@ M.setup = function(setup_config) end
 
 -- This creates a picker with a list of all of the pickers
 M.picker_list = function(opts)
+	-- This is necessary for LSP-related pickers so they can target the correct buffer instead of
+	-- the pickers-list picker buffer (which obvious has no LSP attached).
+	local target_picker_opts = {
+		bufnr = vim.api.nvim_get_current_buf(),
+		winnr = vim.api.nvim_get_current_win(),
+	}
+
 	local opts_list_picker = opts or themes.get_dropdown(opts)
 
 	pickers
@@ -32,7 +39,8 @@ M.picker_list = function(opts)
 					local value = selection.value
 					actions.close(prompt_bufnr)
 					if M.results[value] ~= nil then
-						M.results[value].action(M.results[value].opt)
+						local opts = vim.tbl_extend("force", target_picker_opts, M.results[value].opt)
+						M.results[value].action(opts)
 					end
 				end)
 				return true


### PR DESCRIPTION
Hello o/

Title says it all, when I pick an LSP-related picker using your plugin, it _always_ reports that there are no client attached.

https://github.com/nvim-telescope/telescope.nvim/pull/1706 hints at the reason:
> When buffer/window specific pickers are selected from the `:Telescope builtin` picker, the current buffer & window becomes Telescope itself making many of the pickers practically useless.
>
> This PR sets opts.bufnr and opts.winnr when `:Telescope builtin` is ran. Buffer and window sensitive pickers can then reference those values when called via the builtin picker